### PR TITLE
Den: ScreenOff FOD should be set to false by default

### DIFF
--- a/res/xml/fod_tweaks.xml
+++ b/res/xml/fod_tweaks.xml
@@ -23,7 +23,7 @@
       	    android:key="fod_gesture"
             android:title="@string/fod_gesture_title"
             android:summary="@string/fod_gesture_summary"
-            android:defaultValue="true" />
+            android:defaultValue="false" />
  </PreferenceCategory>
 
         <Preference


### PR DESCRIPTION
-Some OnePlus devices having screen Wakeup issues due to this turned on by default