### PR TITLE
Snowhouse: Escape apostrophe to fix Compile error

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -137,7 +137,7 @@
     <string name="qs_show_brightness_slider_never">Ne pas afficher</string>
     <string name="qs_show_brightness_slider_expanded">Afficher une fois développé</string>
     <string name="qs_show_brightness_slider_always">Toujours afficher</string>
-    <string name="qs_show_brightness_slider_not_expanded">Afficher lorsqu\'il n'est pas développé</string>
+    <string name="qs_show_brightness_slider_not_expanded">Afficher lorsqu\'il n\'est pas développé</string>
     <string name="qs_brightness_slider_position_title">Position</string>
     <string name="qs_brightness_slider_position_top">Haut</string>
     <string name="qs_brightness_slider_position_bottom">Bas</string>


### PR DESCRIPTION
 packages/apps/Settings/SnowHouse/res/values-fr/strings.xml:140: error: unescaped apostrophe in string
 "Afficher lorsqu\'il n'est pas développé".
 packages/apps/Settings/SnowHouse/res/values-fr/strings.xml:140: error: not a valid string.
 packages/apps/Settings/SnowHouse/res/values-fr/strings.xml: error: file failed to compile.

Signed-off-by: GhostMaster69-dev <rathore6375@gmail.com>